### PR TITLE
Honor $COUNT_TEST, don't test on training data.

### DIFF
--- a/roundtrip.sh
+++ b/roundtrip.sh
@@ -6,7 +6,7 @@ echo "generating training data..."
 bin/generate_data --data-path=nyt-ingredients-snapshot-2015.csv --count=$COUNT_TRAIN --offset=0 > tmp/train_file || exit 1
 
 echo "generating test data..."
-bin/generate_data --data-path=nyt-ingredients-snapshot-2015.csv > tmp/test_file || exit 1
+bin/generate_data --data-path=nyt-ingredients-snapshot-2015.csv --count=$COUNT_TEST --offset=$COUNT_TRAIN > tmp/test_file || exit 1
 
 echo "training..."
 crf_learn template_file tmp/train_file tmp/model_file || exit 1


### PR DESCRIPTION
I ran this script, and the generated stats from evaluate.py were unbelievably good:

```
Sentence-Level Stats:
	correct:  91
	total:  100
	% correct:  91.0

Word-Level Stats:
	correct: 572
	total: 588
	% correct: 97.2789115646
```

Looking closer, it seems like the model is being tested on a small amount of the data it was trained on. Providing the additional arguments on line 9:` --count=$COUNT_TEST --offset=$COUNT_TRAIN` fixes that and yields a more reasonable assessment of accuracy:

```
Sentence-Level Stats:
	correct:  1489
	total:  1999
	% correct:  74.4872436218

Word-Level Stats:
	correct: 10399
	total: 11450
	% correct: 90.8209606987
```