### PR TITLE
refactored singularize() to use SnowballStemmer; fixed the smartJoin()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Unidecode==0.04.14
 pandas==0.17.1
+nltk==3.2.4


### PR DESCRIPTION
Summary of changes:

1. refactored singularize() function in utils.py to make use of SnowballStemmer to convert plural words to singular form
2. fixed the smartJoin() function to use regex for whitespace removal
3. fixed a minor bug in use of convert_to_json.py, wherein the output of roundtrip.sh script wasn't compatible. The import_data() now checks if confidence score is available during the conversion process